### PR TITLE
missing dependency

### DIFF
--- a/webform_migrate.info.yml
+++ b/webform_migrate.info.yml
@@ -6,3 +6,4 @@ package: 'Migration'
 dependencies:
   - webform
   - webform_node
+  - migrate_drupal


### PR DESCRIPTION
to enable the use of : 

```
$databases['migrate']['default'] = [
  'database' => 'old_database_d7',
  'username' => 'username',
  'password' => 'password',
  'host' => '127.0.0.1',
  'port' => '3306',
  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
  'driver' => 'mysql',
  'charset' => 'utf8mb4',
  'collation' => 'utf8mb4_swedish_ci',
];
```